### PR TITLE
explicitly set dependencies for latest versions.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,11 @@
     "base64",
     "gzip"
   ],
+  "dependencies": {
+    "stream":"~0.0.2",
+    "util": "~0.10.3",
+    "string_decoder": "~0.10.31"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/mhart/StringStream.git"


### PR DESCRIPTION
* fixes issue where calling inherit on included antiquated version of stream causes 
Uncaught TypeError: Object prototype may only be an Object or null: undefined