### PR TITLE
Fixes out-of-bounds read vulnerability - CWE-125

### DIFF
--- a/stringstream.js
+++ b/stringstream.js
@@ -27,6 +27,9 @@ StringStream.prototype.write = function(data) {
     this.emit('error', err)
     return false
   }
+  if (typeof data !== 'string') {
+    throw new TypeError('"data" argument must be a string')
+  }
   if (this.fromEncoding) {
     if (Buffer.isBuffer(data)) data = data.toString()
     data = new Buffer(data, this.fromEncoding)


### PR DESCRIPTION
See https://hackerone.com/reports/321670 for vulnerability details. Ideally this would be fixed with usage of `Buffer.from`, but we add simple type-checking to keep compatibility with node<4.